### PR TITLE
Add draft placeholder for grabcut class

### DIFF
--- a/grabcut/CMakeLists.txt
+++ b/grabcut/CMakeLists.txt
@@ -3,11 +3,13 @@ add_library(grabcut
         src/orchard-bouman.cpp
         src/grabcut.cpp
         src/segmentation_data.cpp
+        src/fg_bg_graphcut.cpp
         )
 
 target_link_libraries(grabcut PRIVATE
         ${OpenCV_LIBRARIES}
         Eigen3::Eigen
+        maxflow
         )
 target_compile_definitions(grabcut PUBLIC GRABCUT_VERSION="${PROJECT_VERSION}")
 target_include_directories(grabcut PUBLIC

--- a/grabcut/include/gmm/gaussian_mixture_model.hpp
+++ b/grabcut/include/gmm/gaussian_mixture_model.hpp
@@ -66,9 +66,8 @@ public:
                 total_weights += gaussian.a_priori_weight;
             }
         }
-        //FXIME: investigate why sum(total_weights) != 1
         if (total_weights == 0) return 0;
-        return total_probability / total_weights; // clamp(total_probability / total_weights, T(0), T(1));
+        return total_probability / total_weights;
     }
 
     [[nodiscard]]

--- a/grabcut/include/gmm/gaussian_model.hpp
+++ b/grabcut/include/gmm/gaussian_model.hpp
@@ -34,11 +34,14 @@ struct GaussianModel {
     T probability_density(const VecT& v) const noexcept {
         constexpr T pip = detail::pow<T>(2*M_PI, DIM);
         double probability_density(0.);
-        if (determinant > 0) {
+        // TODO: yeah... there might be numerical issues with inverse
+        // so for now let's ignore anything with small determinant
+        if (determinant > T(5e-11)) {
             auto diff = v - mean;
             double distribution = diff.transpose() * (inverse * diff);
             probability_density = std::exp(-0.5 * distribution) / std::sqrt(pip * determinant);
         }
+
         return probability_density;
     }
 

--- a/grabcut/include/grabcut/fg_bg_graphcut.hpp
+++ b/grabcut/include/grabcut/fg_bg_graphcut.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#ifndef GRABCUT_FG_BG_GRAPHCUT_HPP
+#define GRABCUT_FG_BG_GRAPHCUT_HPP
+
+#include "export_macros.h"
+
+struct QuantizationModel;
+
+namespace grabcut {
+
+struct SegmentationData;
+
+/***
+ * It uses maxflow - mincut to segment image
+ */
+class GRABCUT_EXPORT FgBgGraphCut {
+public:
+
+    FgBgGraphCut();
+    ~FgBgGraphCut();
+
+    void build_graph(const Shape shape, const std::uint8_t* imgdata);
+
+    void update_sink_source(const QuantizationModel& color_model, const std::uint8_t* imgdata, const SegmentationData& segdata);
+
+    void run(SegmentationData& segdata);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace grabcut
+
+#endif //GRABCUT_FG_BG_GRAPHCUT_HPP

--- a/grabcut/include/grabcut/grabcut.h
+++ b/grabcut/include/grabcut/grabcut.h
@@ -1,0 +1,31 @@
+#pragma once
+#ifndef GRABCUT_GRABCUT_H
+#define GRABCUT_GRABCUT_H
+
+#include <memory>
+#include <vector>
+
+#include "export_macros.h"
+
+namespace grabcut {
+
+class GRABCUT_EXPORT Grabcut {
+public:
+    Grabcut();
+    ~Grabcut();
+
+    Grabcut& init(const std::uint8_t* image, const std::uint8_t* mask, int width, int height, int channels=3);
+
+    Grabcut& run(int steps=1);
+
+    const std::vector<std::uint8_t>& get_mask() const;
+
+    std::vector<std::uint8_t> get_result() const;
+private:
+    struct GbData;
+    std::unique_ptr<GbData> impl_;
+};
+
+}  // namespace grabcut
+
+#endif //GRABCUT_GRABCUT_H

--- a/grabcut/include/grabcut/segmentation_data.h
+++ b/grabcut/include/grabcut/segmentation_data.h
@@ -11,8 +11,6 @@ namespace grabcut {
 
 struct Shape {
     int width, height, channels;
-    int stride;
-
     int size() const noexcept { return width * height; }
     int chsize() const noexcept { return size() * channels; }
 };

--- a/grabcut/src/fg_bg_graphcut.cpp
+++ b/grabcut/src/fg_bg_graphcut.cpp
@@ -1,0 +1,146 @@
+#include <vector>
+#include <memory>
+#include <graph.h>
+
+#include <grabcut/segmentation_data.h>
+#include <quantization/quantization_model.hpp>
+
+#include <grabcut/fg_bg_graphcut.hpp>
+
+namespace grabcut {
+
+namespace {
+
+constexpr float color_distance_euclid(const std::uint8_t* a, const std::uint8_t* b) noexcept {
+    int res[3] = { b[0] - a[0], b[1] - a[1], b[2] - a[2]};
+    res[0] *= res[0]; res[1] *= res[1]; res[2] *= res[2];
+    return sqrtf(float(res[0] + res[1] + res[2]) / 255.f);
+}
+
+} // namespace
+
+struct FgBgGraphCut::Impl {
+    std::unique_ptr<Graph> graph;
+    std::vector<Graph::node_id> nodes;
+
+    static constexpr float lambda = 50;
+    static constexpr float maximum = 10 * lambda + 1;
+};
+
+FgBgGraphCut::FgBgGraphCut() {
+    impl_ = std::make_unique<Impl>();
+}
+
+FgBgGraphCut::~FgBgGraphCut() = default;
+
+void FgBgGraphCut::build_graph(const Shape shape, const std::uint8_t* imgdata) {
+    const int total = shape.size();
+    auto& graph = impl_->graph;
+    auto& nodes = impl_->nodes;
+
+    graph = std::make_unique<Graph>();
+    nodes.clear();
+    nodes.reserve(total);
+
+    for (int i = 0; i < total; ++i) {
+        nodes.push_back(graph->add_node());
+    }
+
+    constexpr float diag_distance = 1.f / M_SQRT2;
+    constexpr float full_distance = 1.f;
+    constexpr float beta = 0.13f;
+
+    auto diag_weight = [&](float color_distance) -> float {
+        return Impl::lambda * diag_distance * expf(-beta * color_distance);
+    };
+    auto border_weight = [&](float color_distance) -> float {
+        return Impl::lambda * expf(-beta * color_distance);
+    };
+
+    // setup horizontal connections
+    Graph::node_id* ptr = nodes.data();
+    for (int i = 0; i < shape.height; ++i) {
+        for (int j = 0; j < shape.width - 1; ++j) {
+            auto offset = std::distance(nodes.data(), ptr) * 3;
+            float edge_weight = color_distance_euclid(imgdata + offset, imgdata + offset + 3);
+            edge_weight = border_weight(edge_weight);
+            graph->add_edge(*ptr, *(ptr+1), edge_weight, edge_weight);
+            ++ptr;
+        }
+        ++ptr;
+    }
+    // vertical connections
+    Graph::node_id* last_line = nodes.data();
+    Graph::node_id* this_line = nodes.data() + shape.width;
+    for (int i = 1; i < shape.height; ++i) {
+        for (int j = 0; j < shape.width; ++j) {
+            auto offset = std::distance(nodes.data(), this_line) * 3;
+            auto offset_last = std::distance(nodes.data(), last_line) * 3;
+            float edge_weight = color_distance_euclid(imgdata + offset, imgdata + offset_last);
+            edge_weight = border_weight(edge_weight);
+            graph->add_edge(*last_line, *this_line, edge_weight, edge_weight);
+            ++last_line;
+            ++this_line;
+        }
+    }
+
+    // TODO: add diagnoal connectivity
+}
+
+void FgBgGraphCut::update_sink_source(const QuantizationModel &color_model, const std::uint8_t *imgdata,
+                                      const SegmentationData &segdata) {
+    auto& graph = impl_->graph;
+    auto& nodes = impl_->nodes;
+
+    constexpr float maximum_value = Impl::maximum;
+    const auto& foreground = color_model.gmm[0];
+    const auto& background = color_model.gmm[1];
+    auto trimap = segdata.trimap.data();
+    for (auto& node : nodes) {
+        float fg_src_weight = 0;
+        float bg_sink_weight = 0;
+        switch (*trimap) {
+            case Trimap::Foreground:
+                fg_src_weight = maximum_value;
+                break;
+            case Trimap::Background:
+                bg_sink_weight = maximum_value;
+                break;
+            case Trimap::Unknown:
+            default:
+                auto offset = std::distance(segdata.trimap.data(), trimap) * 3;
+                Eigen::Vector3f color(imgdata[offset], imgdata[offset+1], imgdata[offset+2]);
+                color *= 1.f/255.f;
+                // note: the switch between foreground and background weights is correct
+                bg_sink_weight= -logf(foreground.probability(color));
+                fg_src_weight = -logf(background.probability(color));
+        };
+        graph->set_tweights(node, fg_src_weight, bg_sink_weight);
+        ++trimap;
+    }
+}
+
+void FgBgGraphCut::run(SegmentationData &segdata) {
+    auto graph = impl_->graph.get();
+
+    graph->maxflow();
+
+    auto out = segdata.segmap.data();
+    auto node_id = impl_->nodes.data();
+    for (const auto& trimap : segdata.trimap) {
+        switch (trimap) {
+            case Trimap::Background:
+            case Trimap::Foreground:
+                //*out = trimap;
+                //break;
+            default:
+                //*out = Trimap::Foreground;
+                auto seg_id = graph->what_segment(*node_id);
+                *out = seg_id == Graph::SOURCE? Trimap::Foreground : Trimap::Background;
+        };
+        ++out;
+        ++node_id;
+    }
+}
+
+}  // namespace grabcut

--- a/grabcut/src/grabcut.cpp
+++ b/grabcut/src/grabcut.cpp
@@ -1,0 +1,68 @@
+#include <grabcut/grabcut.h>
+
+#include <grabcut/segmentation_data.h>
+#include <quantization/orchard-bouman.h>
+#include <quantization/quantization_model.hpp>
+
+namespace grabcut {
+
+struct Grabcut::GbData {
+    const std::uint8_t* image;
+    Shape shape;
+    SegmentationData segmentation;
+    QuantizationModel color_model;
+    static constexpr int lambda = 50;
+    static constexpr int change_fg_bg_cost = 10 * lambda + 1;
+
+
+    void init(const std::uint8_t* image, const std::uint8_t* mask, int width, int height, int channels) {
+        shape.width = width;
+        shape.height = height;
+        shape.channels = channels;
+        this->image = image;
+        segmentation.init_from(shape, mask);
+        quantization::quantize(image, shape, mask, color_model);
+    }
+
+    void run() {
+        // for now just run slassification based on foreground & background GMM
+        auto out = segmentation.segmap.data();
+        constexpr float to_zero_one = 1.f/255.f;
+        for(auto rgb=image; rgb != image + shape.chsize(); rgb += 3, out += 1) {
+            Eigen::Vector3f color{rgb[0] * to_zero_one, rgb[1] * to_zero_one, rgb[2] * to_zero_one};
+            auto fg = color_model.gmm[0].probability(color);
+            auto bg = color_model.gmm[1].probability(color);
+            *out = fg > bg? Trimap::Foreground : Trimap::Background;
+        }
+
+    }
+
+};
+
+Grabcut::Grabcut() {
+    impl_ = std::make_unique<Grabcut::GbData>();
+}
+
+Grabcut::~Grabcut() = default;
+
+Grabcut& Grabcut::init(const std::uint8_t* image, const std::uint8_t* mask, int width, int height, int channels) {
+    impl_->init(image, mask, width, height, channels);
+    return *this;
+}
+
+Grabcut& Grabcut::run(int steps) {
+    for (int i = 0; i < steps; ++i) {
+        impl_->run();
+    }
+    return *this;
+}
+
+const std::vector<std::uint8_t>& Grabcut::get_mask() const {
+    return impl_->segmentation.segmap;
+};
+
+std::vector<std::uint8_t> Grabcut::get_result() const {
+    return impl_->segmentation.make_rgba(impl_->image, 0, 255);
+}
+
+}  // namespace grabcut

--- a/grabcut/src/grabcut.cpp
+++ b/grabcut/src/grabcut.cpp
@@ -29,10 +29,12 @@ struct Grabcut::GbData {
         auto out = segmentation.segmap.data();
         constexpr float to_zero_one = 1.f/255.f;
         for(auto rgb=image; rgb != image + shape.chsize(); rgb += 3, out += 1) {
-            Eigen::Vector3f color{rgb[0] * to_zero_one, rgb[1] * to_zero_one, rgb[2] * to_zero_one};
-            auto fg = color_model.gmm[0].probability(color);
-            auto bg = color_model.gmm[1].probability(color);
-            *out = fg > bg? Trimap::Foreground : Trimap::Background;
+            if (*out == Trimap::Foreground) {
+                Eigen::Vector3f color{rgb[0] * to_zero_one, rgb[1] * to_zero_one, rgb[2] * to_zero_one};
+                auto fg = color_model.gmm[0].probability(color);
+                auto bg = color_model.gmm[1].probability(color);
+                *out = fg > bg ? Trimap::Foreground : Trimap::Background;
+            }
         }
 
     }

--- a/grabcut/src/segmentation_data.cpp
+++ b/grabcut/src/segmentation_data.cpp
@@ -5,17 +5,17 @@ namespace grabcut {
 void SegmentationData::init_from(Shape _shape, const std::uint8_t *mask) {
     shape = _shape;
     segmap.clear();
+    segmap.assign(shape.size(), Trimap::Background);
     trimap.clear();
-    segmap.resize(shape.size(), Trimap::Background);
-    trimap.resize(shape.size(), Trimap::Unknown);
+    trimap.assign(shape.size(), Trimap::Background);
 
     auto tri = trimap.data();
     auto seg = segmap.data();
 
     for (auto m=mask; m != mask + shape.size(); ++m, ++tri, ++seg) {
         if (*m) {
-            *tri = Trimap::Unknown;
             *seg = Trimap::Foreground;
+            *tri = Trimap::Unknown;
         }
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,3 +9,6 @@ target_link_libraries(test_gmm_mean_covar_precompute PRIVATE grabcut Eigen3::Eig
 
 cpp_test(quantize test_quantize.cpp)
 target_link_libraries(test_quantize PRIVATE grabcut Eigen3::Eigen stb_utils)
+
+cpp_test(grabcut test_grabcut.cpp)
+target_link_libraries(test_grabcut PRIVATE grabcut stb_utils)

--- a/tests/test_grabcut.cpp
+++ b/tests/test_grabcut.cpp
@@ -1,0 +1,59 @@
+#include <doctest.h>
+#include <string>
+#include <stb_image.h>
+#include <stb_image_write.h>
+#include <memory>
+
+#include <grabcut/grabcut.h>
+
+#include <cstdio>
+
+auto data_dir = std::string(TESTDATA_DIR);
+
+std::unique_ptr<std::uint8_t[]> get_flower_rect_mask(int width, int height) {
+    std::unique_ptr<std::uint8_t[]> mask(new std::uint8_t[width * height]);
+    memset(mask.get(), 0, width * height * sizeof(std::uint8_t));
+    // { 68, 29, 533, 494};
+    for (int i = 29; i < 494+29 ; ++i) {
+        for (int j = 68; j < 68+533; ++j) {
+            mask[i * width + j] = 1;
+        }
+    }
+    return mask;
+}
+
+TEST_CASE("Test grabcut implementation") {
+    auto handle = fopen((data_dir + "/flower1.jpg").c_str(), "rb");
+    int width, height, channels;
+    // RGB order, continous image
+    std::uint8_t* image = stbi_load_from_file(handle, &width, &height, &channels, 3);
+    auto img = std::unique_ptr<std::uint8_t, decltype(&stbi_image_free)>(image, stbi_image_free);
+    CHECK_EQ(width, 814);
+    CHECK_EQ(height, 547);
+    CHECK_EQ(channels, 3);
+
+    grabcut::Grabcut grabcut;
+    auto mask = get_flower_rect_mask(width, height);
+
+    SUBCASE("Init grabcut") {
+        grabcut.init(img.get(), mask.get(), width, height, channels);
+        auto rgba = grabcut.get_result();
+        CHECK_EQ(rgba.size(), width * height * 4);
+        stbi_write_png("grab_postinit.png", width, height, 4, rgba.data(), width * 4);
+        std::vector<std::uint8_t> res_mask = grabcut.get_mask();
+        CHECK_EQ(res_mask.size(), width * height);
+        for (auto& m : res_mask) m *= 255;
+        stbi_write_png("grab_postinit_mask.png", width, height, 1, res_mask.data(), width);
+
+        SUBCASE("Run single step") {
+            grabcut.run();
+            rgba = grabcut.get_result();
+            CHECK_EQ(rgba.size(), width * height * 4);
+            stbi_write_png("grab_onestep.png", width, height, 4, rgba.data(), width * 4);
+            res_mask = grabcut.get_mask();
+            CHECK_EQ(res_mask.size(), width * height);
+            for (auto& m : res_mask) m *= 255;
+            stbi_write_png("grab_onestep_mask.png", width, height, 1, res_mask.data(), width);
+        }
+    }
+}

--- a/tests/test_grabcut.cpp
+++ b/tests/test_grabcut.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Test grabcut implementation") {
         for (auto& m : res_mask) m *= 255;
         stbi_write_png("grab_postinit_mask.png", width, height, 1, res_mask.data(), width);
 
-        SUBCASE("Run single step") {
+        SUBCASE("Run 1 step") {
             grabcut.run();
             rgba = grabcut.get_result();
             CHECK_EQ(rgba.size(), width * height * 4);
@@ -54,6 +54,28 @@ TEST_CASE("Test grabcut implementation") {
             CHECK_EQ(res_mask.size(), width * height);
             for (auto& m : res_mask) m *= 255;
             stbi_write_png("grab_onestep_mask.png", width, height, 1, res_mask.data(), width);
+        }
+
+        SUBCASE("Run 2 step") {
+            grabcut.run(2);
+            rgba = grabcut.get_result();
+            CHECK_EQ(rgba.size(), width * height * 4);
+            stbi_write_png("grab_twostep.png", width, height, 4, rgba.data(), width * 4);
+            res_mask = grabcut.get_mask();
+            CHECK_EQ(res_mask.size(), width * height);
+            for (auto& m : res_mask) m *= 255;
+            stbi_write_png("grab_twostep_mask.png", width, height, 1, res_mask.data(), width);
+        }
+
+        SUBCASE("Run 5 steps") {
+            grabcut.run(5);
+            rgba = grabcut.get_result();
+            CHECK_EQ(rgba.size(), width * height * 4);
+            stbi_write_png("grab_nstep.png", width, height, 4, rgba.data(), width * 4);
+            res_mask = grabcut.get_mask();
+            CHECK_EQ(res_mask.size(), width * height);
+            for (auto& m : res_mask) m *= 255;
+            stbi_write_png("grab_nstep_mask.png", width, height, 1, res_mask.data(), width);
         }
     }
 }

--- a/tests/test_grabcut.cpp
+++ b/tests/test_grabcut.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Test grabcut implementation") {
         grabcut.init(img.get(), mask.get(), width, height, channels);
         auto rgba = grabcut.get_result();
         CHECK_EQ(rgba.size(), width * height * 4);
-        stbi_write_png("grab_postinit.png", width, height, 4, rgba.data(), width * 4);
+        stbi_write_png("grab_0.png", width, height, 4, rgba.data(), width * 4);
         std::vector<std::uint8_t> res_mask = grabcut.get_mask();
         CHECK_EQ(res_mask.size(), width * height);
         for (auto& m : res_mask) m *= 255;
@@ -49,7 +49,7 @@ TEST_CASE("Test grabcut implementation") {
             grabcut.run();
             rgba = grabcut.get_result();
             CHECK_EQ(rgba.size(), width * height * 4);
-            stbi_write_png("grab_onestep.png", width, height, 4, rgba.data(), width * 4);
+            stbi_write_png("grab_1.png", width, height, 4, rgba.data(), width * 4);
             res_mask = grabcut.get_mask();
             CHECK_EQ(res_mask.size(), width * height);
             for (auto& m : res_mask) m *= 255;
@@ -60,7 +60,7 @@ TEST_CASE("Test grabcut implementation") {
             grabcut.run(2);
             rgba = grabcut.get_result();
             CHECK_EQ(rgba.size(), width * height * 4);
-            stbi_write_png("grab_twostep.png", width, height, 4, rgba.data(), width * 4);
+            stbi_write_png("grab_2.png", width, height, 4, rgba.data(), width * 4);
             res_mask = grabcut.get_mask();
             CHECK_EQ(res_mask.size(), width * height);
             for (auto& m : res_mask) m *= 255;
@@ -71,11 +71,22 @@ TEST_CASE("Test grabcut implementation") {
             grabcut.run(5);
             rgba = grabcut.get_result();
             CHECK_EQ(rgba.size(), width * height * 4);
-            stbi_write_png("grab_nstep.png", width, height, 4, rgba.data(), width * 4);
+            stbi_write_png("grab_5.png", width, height, 4, rgba.data(), width * 4);
             res_mask = grabcut.get_mask();
             CHECK_EQ(res_mask.size(), width * height);
             for (auto& m : res_mask) m *= 255;
-            stbi_write_png("grab_nstep_mask.png", width, height, 1, res_mask.data(), width);
+            stbi_write_png("grab_fivestep_mask.png", width, height, 1, res_mask.data(), width);
+        }
+
+        SUBCASE("Run 10 steps") {
+            grabcut.run(10);
+            rgba = grabcut.get_result();
+            CHECK_EQ(rgba.size(), width * height * 4);
+            stbi_write_png("grab_10.png", width, height, 4, rgba.data(), width * 4);
+            res_mask = grabcut.get_mask();
+            CHECK_EQ(res_mask.size(), width * height);
+            for (auto& m : res_mask) m *= 255;
+            stbi_write_png("grab_tenstep_mask.png", width, height, 1, res_mask.data(), width);
         }
     }
 }


### PR DESCRIPTION
Added a sketch of grabcut class with test placeholder.

Right now init just calculates GMM (5 gaussians) for foreground/background given mask and run just uses estimated models to segment image.
Given:
![flower1](https://user-images.githubusercontent.com/1038102/177050970-bdbbcbb7-2dc5-4a93-90ee-99359e211c9b.jpg)
With a rectangular binary mask:
![grab_postinit](https://user-images.githubusercontent.com/1038102/177050953-bc78f0f1-0e2d-4ae0-8cb8-97c48abe9fcb.png)
it results in:
![grab_onestep](https://user-images.githubusercontent.com/1038102/177050955-e78c1e79-7436-48b0-95f8-a2e3fe5e0dd5.png)

