### PR TITLE
Use normal color range

### DIFF
--- a/grabcut/include/gmm/build_gaussian.hpp
+++ b/grabcut/include/gmm/build_gaussian.hpp
@@ -1,6 +1,6 @@
+#pragma once
 #ifndef GRABCUT_BUILD_GAUSSIAN_HPP
 #define GRABCUT_BUILD_GAUSSIAN_HPP
-#pragma once
 
 #include "gmm/gaussian_model.hpp"
 #include "gmm/mean_covar_precompute.hpp"
@@ -18,7 +18,7 @@ namespace gmm {
  * @param total_samples total number of observations
  * @return ratio between total samples and points in mean_cov
  */
-template<class T, unsigned DIM>
+template<class T, int DIM>
 void build_gaussian(gmm::GaussianModel<T, DIM> &gaussian, const gmm::MeanCovariancePrecompute<T, DIM>& mean_cov, unsigned total_samples) noexcept {
     static_assert(DIM > 0, "Dimension size must be at least 1");
 
@@ -34,6 +34,29 @@ void build_gaussian(gmm::GaussianModel<T, DIM> &gaussian, const gmm::MeanCovaria
     Eigen::SelfAdjointEigenSolver<decltype(gaussian.covariance)> solver(gaussian.covariance);
     gaussian.eigenvectors = solver.eigenvectors();
     gaussian.eigenvalues = solver.eigenvalues();
+}
+
+/**
+ * From precomputed mean and covariance it computes GaussianModelLite fields like covariance inverce, determinant etc
+ * @tparam T numeric type
+ * @tparam DIM dimensions > 1
+ * @param mean_cov precomputed mean and covariance for subset of samples
+ * @param gaussian a target GaussianModel object
+ * @param total_samples total number of observations
+ * @return ratio between total samples and points in mean_cov
+ */
+template<class T, int DIM>
+void build_gaussian(gmm::GaussianModelLean<T, DIM> &gaussian, const gmm::MeanCovariancePrecompute<T, DIM>& mean_cov, unsigned total_samples) noexcept {
+    static_assert(DIM > 0, "Dimension size must be at least 1");
+
+    gaussian.a_priori_weight = 0;
+    if (mean_cov.size() != 0) {
+        gaussian.a_priori_weight = mean_cov.size() / decltype(gaussian.a_priori_weight)(total_samples);
+    }
+    gaussian.mean = mean_cov.get_mean();
+    auto covariance = mean_cov.get_covariance();
+    gaussian.determinant = covariance.determinant();
+    gaussian.inverse = covariance.inverse();
 }
 
 }  // namespace gmm

--- a/grabcut/include/gmm/gaussian_mixture_model.hpp
+++ b/grabcut/include/gmm/gaussian_mixture_model.hpp
@@ -21,7 +21,7 @@ class GaussianMixtureModel {
 public:
     static_assert(DIM > 0, "At least dim must be 1");
 
-    using GaussianT = GaussianModel<T, DIM>;
+    using GaussianT = GaussianModelLean<T, DIM>;
 
     GaussianMixtureModel() = default;
 
@@ -111,11 +111,6 @@ public:
 
 private:
     std::vector<GaussianT> mixture_;
-};
-
-struct FgBgGMM {
-    GaussianMixtureModel<float, 3> fg;
-    GaussianMixtureModel<float, 3> bg;
 };
 
 } // namespace gmm

--- a/grabcut/include/gmm/mean_covar_precompute.hpp
+++ b/grabcut/include/gmm/mean_covar_precompute.hpp
@@ -80,12 +80,12 @@ public:
     auto get_covariance() const noexcept {
         auto mean = get_mean();
         decltype(prod_) mean_product = mean * mean.transpose();
-
-        decltype(mean) phi;
-        phi.setConstant(5e-15);
-        decltype(prod_) ensure_invertible = phi.asDiagonal();
-
-        decltype(prod_) covariance = ((prod_ / n_) - mean_product) + ensure_invertible;
+        decltype(prod_) covariance = ((prod_ / n_) - mean_product);
+        if (covariance.determinant() < 1e-6) {
+            decltype(mean) phi;
+            phi.setConstant(0.1);
+            covariance += phi.asDiagonal();
+        }
         return covariance;
     }
 

--- a/grabcut/include/gmm/mean_covar_precompute.hpp
+++ b/grabcut/include/gmm/mean_covar_precompute.hpp
@@ -11,7 +11,7 @@ namespace gmm {
   * @tparam T numeric type for values
  * @tparam DIM dimension size
  */
-template<class T, unsigned DIM=3>
+template<class T, int DIM=3>
 class MeanCovariancePrecompute {
 public:
     using MatT = Eigen::Matrix<T, DIM, DIM>;

--- a/grabcut/src/fg_bg_graphcut.cpp
+++ b/grabcut/src/fg_bg_graphcut.cpp
@@ -13,8 +13,7 @@ namespace {
 
 constexpr float color_distance_euclid(const std::uint8_t* x, const std::uint8_t* y) noexcept {
     int res[3] = { y[0] - x[0], y[1] - x[1], y[2] - x[2]};
-    float r(res[0]/255.f), g(res[1]/255.f), b(res[2]/255.f);
-    return r*r + g*g + b*b;
+    return static_cast<float>(res[0]*res[0] + res[1]*res[1]+ res[2]*res[2]);
 }
 
 } // namespace
@@ -154,7 +153,6 @@ void FgBgGraphCut::update_sink_source(const QuantizationModel &color_model, cons
             default:
                 auto offset = std::distance(segdata.trimap.data(), trimap) * 3;
                 Eigen::Vector3d color(imgdata[offset], imgdata[offset+1], imgdata[offset+2]);
-                color *= 1.f/255.f;
                 // note: the switch between foreground and background weights is correct
                 bg_source_weight= -log(foreground.probability(color));
                 fg_sink_weight = -log(background.probability(color));

--- a/grabcut/src/learn_gmm.cpp
+++ b/grabcut/src/learn_gmm.cpp
@@ -41,7 +41,7 @@ void learn(QuantizationModel& model, const grabcut::SegmentationData& segdata, c
         total_fg_size += mix.size();
     }
     for (size_t k = 0; k < fg.size(); ++k) {
-        gmm::build_gaussian<double, 3>(fg[k], fg_gmm[k], total_fg_size);
+        gmm::build_gaussian(fg[k], fg_gmm[k], total_fg_size);
     }
 
     size_t total_bg_size = 0;
@@ -49,7 +49,7 @@ void learn(QuantizationModel& model, const grabcut::SegmentationData& segdata, c
         total_bg_size += mix.size();
     }
     for (size_t k = 0; k < fg.size(); ++k) {
-        gmm::build_gaussian<double, 3>(bg[k], bg_gmm[k], total_bg_size);
+        gmm::build_gaussian(bg[k], bg_gmm[k], total_bg_size);
     }
 }
 

--- a/grabcut/src/learn_gmm.cpp
+++ b/grabcut/src/learn_gmm.cpp
@@ -13,14 +13,11 @@ void learn(QuantizationModel& model, const grabcut::SegmentationData& segdata, c
     auto& fg = model.gmm[0];
     auto& bg = model.gmm[1];
 
-    constexpr float to_zero_one = 1.f / 255.f;
-
     auto col = colors;
     auto mask = segdata.segmap.data();
     const auto end = model.component_map.data() + model.component_map.size();
     for (auto component = model.component_map.data(); component != end; ++component, ++mask, col += 3) {
         Eigen::Vector3d color(col[0], col[1], col[2]);
-        color *= to_zero_one;
         *component = *mask == Trimap::Background? bg.strongest_k(color) : fg.strongest_k(color);
     }
 
@@ -31,7 +28,6 @@ void learn(QuantizationModel& model, const grabcut::SegmentationData& segdata, c
     col = colors;
     for (auto component = model.component_map.data(); component != end; ++component, ++mask, col += 3) {
         Eigen::Vector3d color(col[0], col[1], col[2]);
-        color *= to_zero_one;
         auto& mixture = *mask == Trimap::Background? bg_gmm : fg_gmm;
         mixture[*component].add(color);
     }

--- a/grabcut/src/orchard-bouman.cpp
+++ b/grabcut/src/orchard-bouman.cpp
@@ -44,8 +44,6 @@ struct DynamicGaussianComponent {
 void split_biggest_gaussian(const uint8_t *data, const grabcut::Shape &shape, const uint8_t *mask_data,
                             std::vector<DynamicGaussianComponent> &fg_gmm, std::vector<DynamicGaussianComponent> &bg_gmm,
                             std::vector<std::uint8_t> &gmm_component_map, int fg_id, int bg_id, int k) {
-    constexpr float to_zero_one = 1.f / 255.f;
-
     if (fg_id == k && bg_id == k) {
         return;
     }
@@ -87,7 +85,6 @@ void split_biggest_gaussian(const uint8_t *data, const grabcut::Shape &shape, co
     }
     while (curr != end) {
         Eigen::Vector3d color(curr[0], curr[1], curr[2]);
-        color *= to_zero_one;
         if (fg_id != k && *mask_curr == grabcut::Foreground && *gmm_c == fg_id) {
             if (split_force(fg, color) > split_force_fg) {
                 *gmm_c = static_cast<uint8_t>(k);
@@ -130,10 +127,8 @@ void quantize(const std::uint8_t* data, const grabcut::Shape& shape, const std::
     const std::uint8_t* mask_curr = mask_data;
     const std::uint8_t* end = data + (shape.width * shape.height * shape.channels);
 
-    constexpr float to_zero_one = 1.f/255.f;
     while (curr != end) {
         Eigen::Vector3d color(curr[0], curr[1], curr[2]);
-        color *= to_zero_one;
         switch(*mask_curr) {
             case grabcut::Trimap::Background:
                 bg_gmm.front().data.add(color);

--- a/grabcut/src/orchard-bouman.cpp
+++ b/grabcut/src/orchard-bouman.cpp
@@ -27,12 +27,12 @@ struct DynamicGaussianComponent {
     }
 
     DynamicGaussianComponent& update(size_t size) {
-        gmm::build_gaussian<double, 3>(gaussian, data, size);
+        gmm::build_gaussian(gaussian, data, size);
         return *this;
     }
 
     DynamicGaussianComponent& update() {
-        gmm::build_gaussian<double, 3>(gaussian, data, data.size());
+        gmm::build_gaussian(gaussian, data, data.size());
         return *this;
     }
 
@@ -187,8 +187,8 @@ void quantize(const std::uint8_t* data, const grabcut::Shape& shape, const std::
     final_bg_gmm.clear();
 
     for (int i = 0; i < max_k; ++i) {
-        final_fg_gmm.add(std::move(fg_gmm[i].gaussian));
-        final_bg_gmm.add(std::move(bg_gmm[i].gaussian));
+        final_fg_gmm.add(fg_gmm[i].gaussian.get_lean());
+        final_bg_gmm.add(bg_gmm[i].gaussian.get_lean());
     }
 }
 


### PR DESCRIPTION
Do not normalize colors to 0..1 range. It results in numeric issues I don't know yet how to fix with covariance inverse matrix.
With this fix, segmentation works in case of more uniform background/fg colors.