### PR TITLE
Precompute weights

### DIFF
--- a/grabcut/include/grabcut/fg_bg_graphcut.hpp
+++ b/grabcut/include/grabcut/fg_bg_graphcut.hpp
@@ -19,13 +19,15 @@ public:
     FgBgGraphCut();
     ~FgBgGraphCut();
 
-    void build_graph(const Shape shape, const std::uint8_t* imgdata);
+    void build_graph(Shape shape, const std::uint8_t* imgdata);
 
     void update_sink_source(const QuantizationModel& color_model, const std::uint8_t* imgdata, const SegmentationData& segdata);
 
     bool run(SegmentationData& segdata);
 
-    void estimate_beta(const Shape shape, const std::uint8_t* imgdata) noexcept;
+    void estimate_beta(Shape shape, const std::uint8_t* imgdata) noexcept;
+
+    void precompute_edge_weights(Shape shape, const std::uint8_t* imgdata);
 
 private:
     struct Impl;

--- a/grabcut/src/fg_bg_graphcut.cpp
+++ b/grabcut/src/fg_bg_graphcut.cpp
@@ -145,11 +145,6 @@ void FgBgGraphCut::build_graph(const Shape shape, const std::uint8_t* imgdata) {
         nodes.push_back(graph->addVtx());
     }
 
-    const float beta = impl_->beta;
-
-    auto diag_weight = [beta](float color_distance) -> float {
-        return (Impl::lambda / float(M_SQRT2)) * expf(-beta * color_distance);
-    };
     // setup horizontal connections
     auto* ptr = nodes.data();
     const auto* hedge = impl_->edge_weights_horizontal.data();

--- a/grabcut/src/grabcut.cpp
+++ b/grabcut/src/grabcut.cpp
@@ -24,6 +24,7 @@ struct Grabcut::GbData {
         segmentation.init_from(shape, mask);
         converged = false;
         graphcut.estimate_beta(shape, image);
+        graphcut.precompute_edge_weights(shape, image);
     }
 
     void run() {


### PR DESCRIPTION
For more than 1 iteration it makes sense to calculate weights between pixels only once and reusue them for every build graph.